### PR TITLE
Improve error message on workflow launch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,11 @@ jobs:
         name: Download the agent
         command: curl https://install.zenaton.com | sh
 
+    # take the copy out when agent bug is fixed
     - run:
         name: Run integration tests
         command: |
           go get github.com/zenaton/agent-integration/go
           cd $(go env GOPATH)/src/github.com/zenaton/agent-integration/go
+          cp test_listen ~/.zenaton/lib/worker-0.4.5/priv/go/default/scripts/test_listen.go
           go test -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,11 +40,9 @@ jobs:
         name: Download the agent
         command: curl https://install.zenaton.com | sh
 
-    # take the copy out when agent bug is fixed
     - run:
         name: Run integration tests
         command: |
           go get github.com/zenaton/agent-integration/go
           cd $(go env GOPATH)/src/github.com/zenaton/agent-integration/go
-          cp test_listen ~/.zenaton/lib/worker-0.4.4/priv/go/default/scripts/test_listen.go
           go test -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- improved error message when you try to launch a workflow without having listened yet
+
 ## 0.2.0 - 2018-10-14
 ### Added
 - add integration tests to circle ci.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Fixed
 - improved error message when you try to launch a workflow without having listened yet
+- circle ci build to not copy the test_listen file anymore
 
 ## 0.2.0 - 2018-10-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Fixed
 - improved error message when you try to launch a workflow without having listened yet
-- circle ci build to not copy the test_listen file anymore
+- changes cp command in circle ci
 
 ## 0.2.0 - 2018-10-14
 ### Added

--- a/v1/zenaton/internal/client/client.go
+++ b/v1/zenaton/internal/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"runtime"
@@ -155,8 +156,14 @@ func (c *Client) StartWorkflow(flowName, flowCanonical, customID string, data in
 	if err != nil {
 		panic(err)
 	}
+
 	if strings.Contains(string(respBody), `Your worker does not listen to app`) {
-		panic(string(respBody))
+
+		var errResponse map[string]string
+		json.Unmarshal(respBody, &errResponse)
+
+		log.Println(errResponse["error"])
+		log.Fatal("please run the 'zenaton listen' command. For example: 'zenaton listen --env=.env --boot=boot/boot.go'")
 	}
 }
 


### PR DESCRIPTION
![screen shot 2018-10-30 at 12 23 57 pm](https://user-images.githubusercontent.com/10984149/47744525-bd7d7900-dc3e-11e8-8d92-08c5a1b7c69b.png)

Now when you try to launch a workflow without having listened, you get a better error message.