### PR TITLE
Fixes weekday and DayOfMonth methods to wait until the specified next day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### fixes
+- fixes wait weekday and DayOfMonth wait methods when the given day is the same as today.
+
 ## 0.2.0 - 2018-10-14
 ### Added
 - add integration tests to circle ci.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### fixes
-- fixes wait weekday and DayOfMonth wait methods when the given day is the same as today.
+- fixes wait weekday and DayOfMonth methods when the given day is the same as today.
 
 ## 0.2.0 - 2018-10-14
 ### Added

--- a/v1/zenaton/task/wait.go
+++ b/v1/zenaton/task/wait.go
@@ -380,9 +380,9 @@ func (w *WaitTask) _dayOfMonth(day int, now, then time.Time) (time.Time, error) 
 		return time.Time{}, err
 	}
 
-	then = time.Date(now.Year(), now.Month(), day, now.Hour(), now.Minute(), now.Second(), now.Nanosecond(), w.timezone)
+	then = time.Date(then.Year(), then.Month(), day, then.Hour(), then.Minute(), then.Second(), then.Nanosecond(), w.timezone)
 
-	if now.After(then) || now.Day() == then.Day() {
+	if (now.After(then) || now.Day() == then.Day()) && !containsAtMethod(w.buffer) {
 		then = then.AddDate(0, 1, 0)
 	}
 
@@ -398,13 +398,22 @@ func (w *WaitTask) _weekDay(n int, weekday time.Weekday, then time.Time) (time.T
 	thenWeekday := then.Weekday()
 	then = then.AddDate(0, 0, int(weekday-thenWeekday))
 
-	if thenWeekday >= weekday {
+	if thenWeekday >= weekday && !containsAtMethod(w.buffer) {
 		then = then.AddDate(0, 0, n*7)
 	} else {
 		then = then.AddDate(0, 0, (n-1)*7)
 	}
 
 	return then, nil
+}
+
+func containsAtMethod(buffer []duration) bool {
+	for _, dur := range buffer {
+		if dur.method == "at" {
+			return true
+		}
+	}
+	return false
 }
 
 func (w *WaitTask) _setMode(mode string) error {

--- a/v1/zenaton/task/wait.go
+++ b/v1/zenaton/task/wait.go
@@ -382,26 +382,26 @@ func (w *WaitTask) _dayOfMonth(day int, now, then time.Time) (time.Time, error) 
 
 	then = time.Date(now.Year(), now.Month(), day, now.Hour(), now.Minute(), now.Second(), now.Nanosecond(), w.timezone)
 
-	if now.After(then) {
+	if now.After(then) || now.Day() == then.Day() {
 		then = then.AddDate(0, 1, 0)
 	}
 
 	return then, nil
 }
 
-func (w *WaitTask) _weekDay(n int, day int, then time.Time) (time.Time, error) {
+func (w *WaitTask) _weekDay(n int, weekday time.Weekday, then time.Time) (time.Time, error) {
 	err := w._setMode(modeWeekDay)
 	if err != nil {
 		return time.Time{}, err
 	}
 
-	d := int(then.Weekday())
-	then = then.AddDate(0, 0, day-d)
+	thenWeekday := then.Weekday()
+	then = then.AddDate(0, 0, int(weekday-thenWeekday))
 
-	if d > day {
-		then.AddDate(0, 0, n*7)
+	if thenWeekday >= weekday {
+		then = then.AddDate(0, 0, n*7)
 	} else {
-		then.AddDate(0, 0, (n-1)*7)
+		then = then.AddDate(0, 0, (n-1)*7)
 	}
 
 	return then, nil


### PR DESCRIPTION
per the discussion with @geomagilles: 

if we are Monday, 11am on the 23rd of the month. Then: 

.Monday(1) should wait until next Monday at 11am 
.Monday(1).At("9") should wait until next Monday at 9am 
.Monday(1).At("13") should wait 2 hours only 
.DayOfMonth(23) should wait for one month 
.DayOfMonth(23).At("13") should wait for only 2 hours.